### PR TITLE
Active la fonction de déploiement en git tag et pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
 
       - run:
           name: Run tests
-          command: make test
+          command: |
+            source /tmp/venv/france_dotations_locales/bin/activate
+            make test
 
   check_version:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py37-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -25,7 +25,7 @@ jobs:
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH#egg=OpenFisca-Core[web-api]  # use a specific branch of OpenFisca-Core
 
       - save_cache:
-          key: v1-py37-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/france_dotations_locales
 
@@ -62,7 +62,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py37-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - restore_cache:
           key: v1-py37-build-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     docker:
       - image: python:3.7
     environment:
-      PYPI_USERNAME: openfisca-bot  # Edit this value to replace it by your Pypi username
+      PYPI_USERNAME: leximpact-bot  # Edit this value to replace it by your Pypi username
       # PYPI_PASSWORD: this value is set in CircleCI's web interface; do not set it here, it is a secret!
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
       - image: python:3.7
 
     steps:
+      - checkout
+
       - restore_cache:
           key: v1-py37-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,9 @@ workflows:
   build_and_deploy:
     jobs:
       - build
-      - test
+      - test:
+          requires:
+            - build
       - check_version
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,9 @@ workflows:
       - test:
           requires:
             - build
-      - check_version
+      - check_version:
+          requires:
+            - build
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -25,12 +25,12 @@ jobs:
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH#egg=OpenFisca-Core[web-api]  # use a specific branch of OpenFisca-Core
 
       - save_cache:
-          key: v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/france_dotations_locales
 
       - save_cache:
-          key: v1-py3-build-{{ .Revision }}
+          key: v1-py37-build-{{ .Revision }}
           paths:
             - dist
 
@@ -62,10 +62,10 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py37-deps-{{ checksum "setup.py" }}
 
       - restore_cache:
-          key: v1-py3-build-{{ .Revision }}
+          key: v1-py37-build-{{ .Revision }}
 
       - run:
           name: Check for functional changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             echo "source /tmp/venv/france_dotations_locales/bin/activate" >> $BASH_ENV
 
       - run:
-          name: Install dependencies
+          name: Remove old builds, install dependencies and build new wheel
           command: |
             make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH#egg=OpenFisca-Core[web-api]  # use a specific branch of OpenFisca-Core
@@ -33,6 +33,17 @@ jobs:
           key: v1-py37-build-{{ .Revision }}
           paths:
             - dist
+
+  test:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - restore_cache:
+          key: v1-py37-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - restore_cache:
+          key: v1-py37-build-{{ .Revision }}
 
       - run:
           name: Run tests
@@ -72,7 +83,7 @@ jobs:
           command: if ! .circleci/has-functional-changes.sh ; then circleci step halt ; fi
 
       - run:
-          name: Upload a Python package to Pypi
+          name: Upload built Python package to Pypi
           command: |
             source /tmp/venv/france_dotations_locales/bin/activate
             twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
@@ -86,10 +97,12 @@ workflows:
   build_and_deploy:
     jobs:
       - build
+      - test
       - check_version
       - deploy:
           requires:
             - build
+            - test
             - check_version
           filters:
             branches:

--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -2,11 +2,22 @@
 
 IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
 
-last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
+remote_tags_exist=`git ls-remote --tags origin`
 
-if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
+if [[ $remote_tags_exist ]];
+then
+  # get last tagged commit
+  commit_to_compare_to=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
+else
+  # get remote master branch last commit
+  commit_to_compare_to=`git rev-parse origin/master`
+fi
+
+
+if git diff-index --name-only --exit-code $commit_to_compare_to -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
 then
   echo "No functional changes detected."
   exit 1
-else echo "The functional files above were changed."
+else
+  echo "The functional files above were changed."
 fi

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check-style:
 	flake8 `git ls-files | grep "\.py$$"`
 
 test: clean check-syntax-errors check-style
-	openfisca-run-test --country-package openfisca_france_dotations_locales tests
+	openfisca test --country-package openfisca_france_dotations_locales tests
 
 serve-local: build
 	openfisca serve --country-package openfisca_france_dotations_locales

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenFisca France Dotations Locales
 
+[![CircleCI](https://circleci.com/gh/leximpact/openfisca-france-dotations-locales.svg?style=shield)](https://circleci.com/gh/leximpact/openfisca-france-dotations-locales)
+
 [EN] OpenFisca tax and benefit system for France State endowments to local authorities.
 
 [FR] Modèle de microsimulation OpenFisca dédié aux dotations de l'État aux collectivités territoriales.


### PR DESCRIPTION
* Amélioration technique ne nécessitant pas de mise à jour de version.
* Détails :
  - Cette PR est associée avec : 
     - la création d'un compte pypi au nom de `leximpact-bot`
     - l'activation du dépôt sur CircleCI et l'ajout dans ses variables d'environnement du mot de passe pour `leximpact-bot`
  - Définit les dépendances entre jobs et sépare le job `test` du `build` dans CircleCI
  - Renomme les cache sur CircleCI pour intégrer en particulier le nom de la branche (source de bugs sinon)
  - Amende le script de vérification des changements fonctionnels pour l'adapter à notre cas : dépôt n'ayant pas encore de git tags
  - Ajoute un badge en haut du README donnant le status CircleCI

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

😞  La mise à jour du script `has_functional_changes.sh` est inutile car il survient après le merge sur master (donc le dernier commit sur master n'est pas un bon point de référence).

Il manquait à cette PR le fait de donner l'autorisation à CircleCI de tagger sur GitHub via un compte GitHub `leximpact-bot` tel que décrit dans [cette PR](https://github.com/openfisca/extension-template/pull/15) openfisca `extension-template`.