### PR TITLE
Removing 'divide by zero' warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-### 0.7.3 inprogress 
+### 0.7.3 [#15] (https://github.com/leximpact/openfisca-france-dotations-locales/pull/15)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france_dotations_locales/variables/base.py`.
+* Détails :
+  - Suppression des warnings 'divide by zero' dans la fonction custom de division que nous avons écrite (et qui fait bien attention à ne pas diviser par zéro)
+
 ### 0.7.2 [#14](https://github.com/leximpact/openfisca-france-dotations-locales/pull/14)
 
 * Amélioration technique.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+### 0.7.3 inprogress 
 ### 0.7.2 [#14](https://github.com/leximpact/openfisca-france-dotations-locales/pull/14)
 
 * Amélioration technique.

--- a/openfisca_france_dotations_locales/variables/agglomeration.py
+++ b/openfisca_france_dotations_locales/variables/agglomeration.py
@@ -1,5 +1,6 @@
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class population_dgf_agglomeration(Variable):
@@ -45,7 +46,7 @@ class part_population_agglomeration_departement(Variable):
     def formula(commune, period, parameters):
         population_dgf_agglomeration = commune("population_dgf_agglomeration", period)
         population_dgf_departement_agglomeration = commune("population_dgf_departement_agglomeration", period)
-        return where(population_dgf_departement_agglomeration > 0, population_dgf_agglomeration / population_dgf_departement_agglomeration, 0)
+        return safe_divide(population_dgf_agglomeration, population_dgf_departement_agglomeration, 0)
 
 
 class population_dgf_maximum_commune_agglomeration(Variable):

--- a/openfisca_france_dotations_locales/variables/base.py
+++ b/openfisca_france_dotations_locales/variables/base.py
@@ -2,4 +2,5 @@ import numpy as np
 
 
 def safe_divide(a, b, value_if_error=0):
+    np.seterr(divide='ignore')
     return np.where(b != 0, np.divide(a, b), value_if_error)

--- a/openfisca_france_dotations_locales/variables/base.py
+++ b/openfisca_france_dotations_locales/variables/base.py
@@ -2,5 +2,5 @@ import numpy as np
 
 
 def safe_divide(a, b, value_if_error=0):
-    np.seterr(divide='ignore')
-    return np.where(b != 0, np.divide(a, b), value_if_error)
+    with np.errstate(divide='ignore'):
+        return np.where(b != 0, np.divide(a, b), value_if_error)

--- a/openfisca_france_dotations_locales/variables/base.py
+++ b/openfisca_france_dotations_locales/variables/base.py
@@ -2,6 +2,5 @@ import numpy as np
 
 
 def safe_divide(a, b, value_if_error=0):
-    # x = np.divide(a,b)
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         return np.where(b != 0, np.divide(a, b), value_if_error)

--- a/openfisca_france_dotations_locales/variables/base.py
+++ b/openfisca_france_dotations_locales/variables/base.py
@@ -2,5 +2,6 @@ import numpy as np
 
 
 def safe_divide(a, b, value_if_error=0):
+    # x = np.divide(a,b)
     with np.errstate(divide='ignore'):
         return np.where(b != 0, np.divide(a, b), value_if_error)

--- a/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
+++ b/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
@@ -1,6 +1,7 @@
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
 from numpy import log10, where
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class dotation_forfaitaire(Variable):
@@ -184,7 +185,7 @@ class df_evolution_part_dynamique(Variable):
 
         facteur_minimum = parameters(period).dotation_forfaitaire.montant_minimum_par_habitant
         facteur_maximum = parameters(period).dotation_forfaitaire.montant_maximum_par_habitant
-        dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(population_majoree_dgf / plancher_dgcl_population_dgf_majoree)))
+        dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1))))
         return dotation_supp_par_habitant * evolution_population
 
 

--- a/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
+++ b/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
@@ -178,13 +178,22 @@ class df_evolution_part_dynamique(Variable):
     def formula(commune, period, parameters):
         plancher_dgcl_population_dgf_majoree = 500
         plafond_dgcl_population_dgf_majoree = 200000
-        facteur_du_coefficient_logarithmique = safe_divide(1, log10(safe_divide(plafond_dgcl_population_dgf_majoree, plancher_dgcl_population_dgf_majoree, 1)), 0)  # le fameux 0.38431089
+        facteur_du_coefficient_logarithmique = 1 / (log10(plafond_dgcl_population_dgf_majoree / plancher_dgcl_population_dgf_majoree))  # le fameux 0.38431089
         population_majoree_dgf = commune('population_dgf_majoree', period)
         population_majoree_dgf_an_dernier = commune('population_dgf_majoree', period.last_year)
         evolution_population = population_majoree_dgf - population_majoree_dgf_an_dernier
 
         facteur_minimum = parameters(period).dotation_forfaitaire.montant_minimum_par_habitant
         facteur_maximum = parameters(period).dotation_forfaitaire.montant_maximum_par_habitant
+        # dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(population_majoree_dgf / plancher_dgcl_population_dgf_majoree)))
+        print(facteur_minimum, facteur_maximum,
+            max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1)))),
+            min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1))),
+            facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1)),
+            log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree)),
+            safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree),
+            population_majoree_dgf, plancher_dgcl_population_dgf_majoree,
+        )
         dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1))))
         return dotation_supp_par_habitant * evolution_population
 

--- a/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
+++ b/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
@@ -185,15 +185,6 @@ class df_evolution_part_dynamique(Variable):
 
         facteur_minimum = parameters(period).dotation_forfaitaire.montant_minimum_par_habitant
         facteur_maximum = parameters(period).dotation_forfaitaire.montant_maximum_par_habitant
-        # dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(population_majoree_dgf / plancher_dgcl_population_dgf_majoree)))
-        print(facteur_minimum, facteur_maximum,
-            max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1)))),
-            min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1))),
-            facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1)),
-            log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree)),
-            safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree),
-            population_majoree_dgf, plancher_dgcl_population_dgf_majoree,
-        )
         dotation_supp_par_habitant = facteur_minimum + (facteur_maximum - facteur_minimum) * max_(0, min_(1, facteur_du_coefficient_logarithmique * log10(safe_divide(population_majoree_dgf, plancher_dgcl_population_dgf_majoree, 1))))
         return dotation_supp_par_habitant * evolution_population
 

--- a/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
+++ b/openfisca_france_dotations_locales/variables/dotation_forfaitaire.py
@@ -178,7 +178,7 @@ class df_evolution_part_dynamique(Variable):
     def formula(commune, period, parameters):
         plancher_dgcl_population_dgf_majoree = 500
         plafond_dgcl_population_dgf_majoree = 200000
-        facteur_du_coefficient_logarithmique = 1 / (log10(plafond_dgcl_population_dgf_majoree / plancher_dgcl_population_dgf_majoree))  # le fameux 0.38431089
+        facteur_du_coefficient_logarithmique = safe_divide(1, log10(safe_divide(plafond_dgcl_population_dgf_majoree, plancher_dgcl_population_dgf_majoree, 1)), 0)  # le fameux 0.38431089
         population_majoree_dgf = commune('population_dgf_majoree', period)
         population_majoree_dgf_an_dernier = commune('population_dgf_majoree', period.last_year)
         evolution_population = population_majoree_dgf - population_majoree_dgf_an_dernier

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/bourg_centre.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/bourg_centre.py
@@ -1,7 +1,6 @@
 from numpy import sum as sum_, where
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
-from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class dsr_exclue_fraction_bourg_centre_agglomeration(Variable):
@@ -68,9 +67,9 @@ class dsr_exclue_fraction_bourg_centre_pfi(Variable):
         taille_max_commune = parameters(period).dotation_solidarite_rurale.seuil_nombre_habitants
         # oui le taille_max_commune est le même que pour le seuil d'éligibilité, notre paramétrisation est ainsi
         communes_moins_10000 = (~outre_mer) * (population_dgf < taille_max_commune)
-        if sum_(communes_moins_10000 * population_dgf) != 0 :
+        if sum_(communes_moins_10000 * population_dgf) != 0:
             pot_fin_10000 = sum_(communes_moins_10000 * potentiel_financier) / sum_(communes_moins_10000 * population_dgf)
-        else :
+        else:
             pot_fin_10000 = 0
         return potentiel_financier_par_habitant >= (ratio_max_potentiel_financier * pot_fin_10000)
 
@@ -103,7 +102,6 @@ class dsr_exclue_fraction_bourg_centre_type_2(Variable):
         # Sources d'exclusion de l'éligibilité...
         dsr_exclue_fraction_bourg_centre_agglomeration = commune("dsr_exclue_fraction_bourg_centre_agglomeration", period)
         dsr_exclue_fraction_bourg_centre_pfi = commune("dsr_exclue_fraction_bourg_centre_pfi", period)
-         
         return (dsr_exclue_fraction_bourg_centre_agglomeration
             | dsr_exclue_fraction_bourg_centre_pfi)
 

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/bourg_centre.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/bourg_centre.py
@@ -1,6 +1,7 @@
 from numpy import sum as sum_, where
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class dsr_exclue_fraction_bourg_centre_agglomeration(Variable):
@@ -67,8 +68,10 @@ class dsr_exclue_fraction_bourg_centre_pfi(Variable):
         taille_max_commune = parameters(period).dotation_solidarite_rurale.seuil_nombre_habitants
         # oui le taille_max_commune est le même que pour le seuil d'éligibilité, notre paramétrisation est ainsi
         communes_moins_10000 = (~outre_mer) * (population_dgf < taille_max_commune)
-        pot_fin_10000 = (sum_(communes_moins_10000 * potentiel_financier)
-                / sum_(communes_moins_10000 * population_dgf))
+        if sum_(communes_moins_10000 * population_dgf) != 0 :
+            pot_fin_10000 = sum_(communes_moins_10000 * potentiel_financier) / sum_(communes_moins_10000 * population_dgf)
+        else :
+            pot_fin_10000 = 0
         return potentiel_financier_par_habitant >= (ratio_max_potentiel_financier * pot_fin_10000)
 
 
@@ -84,7 +87,6 @@ class dsr_exclue_fraction_bourg_centre_type_1(Variable):
         dsr_exclue_fraction_bourg_centre_agglomeration = commune("dsr_exclue_fraction_bourg_centre_agglomeration", period)
         dsr_exclue_fraction_bourg_centre_canton = commune("dsr_exclue_fraction_bourg_centre_canton", period)
         dsr_exclue_fraction_bourg_centre_pfi = commune("dsr_exclue_fraction_bourg_centre_pfi", period)
-
         return (dsr_exclue_fraction_bourg_centre_agglomeration
             | dsr_exclue_fraction_bourg_centre_canton
             | dsr_exclue_fraction_bourg_centre_pfi)
@@ -101,7 +103,7 @@ class dsr_exclue_fraction_bourg_centre_type_2(Variable):
         # Sources d'exclusion de l'éligibilité...
         dsr_exclue_fraction_bourg_centre_agglomeration = commune("dsr_exclue_fraction_bourg_centre_agglomeration", period)
         dsr_exclue_fraction_bourg_centre_pfi = commune("dsr_exclue_fraction_bourg_centre_pfi", period)
-
+         
         return (dsr_exclue_fraction_bourg_centre_agglomeration
             | dsr_exclue_fraction_bourg_centre_pfi)
 

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/cible.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/cible.py
@@ -215,7 +215,7 @@ class dsr_score_attribution_cible_part_potentiel_financier_par_habitant(Variable
         population_dgf = commune('population_dgf', period)
 
         plafond_effort_fiscal = parameters(period).dotation_solidarite_rurale.attribution.plafond_effort_fiscal
-        facteur_pot_fin = where(potentiel_financier_par_habitant_strate > 0, max_(0, 2 - potentiel_financier_par_habitant / potentiel_financier_par_habitant_strate), 0)
+        facteur_pot_fin = max_(0, 2 - safe_divide(potentiel_financier_par_habitant, potentiel_financier_par_habitant_strate, 2))
         facteur_effort_fiscal = np.minimum(plafond_effort_fiscal, effort_fiscal)
 
         return dsr_eligible_fraction_cible * population_dgf * facteur_pot_fin * facteur_effort_fiscal

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/cible.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/cible.py
@@ -1,6 +1,7 @@
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
 import numpy as np
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class indice_synthetique_dsr_cible(Variable):
@@ -30,8 +31,8 @@ class indice_synthetique_dsr_cible(Variable):
 
         return ((population_dgf < limite_population)
             * (dsr_eligible_fraction_bourg_centre | dsr_eligible_fraction_perequation)
-            * (poids_pot_fin * where(potentiel_financier_par_habitant > 0, potentiel_financier_par_habitant_strate / potentiel_financier_par_habitant, 0)
-            + poids_revenu * where(revenu_par_habitant > 0, revenu_par_habitant_strate / revenu_par_habitant, 0))
+            * (poids_pot_fin * safe_divide(potentiel_financier_par_habitant_strate, potentiel_financier_par_habitant, 0)
+            + poids_revenu * safe_divide(revenu_par_habitant_strate, revenu_par_habitant, 0))
             )
 
 
@@ -291,10 +292,9 @@ class dsr_score_attribution_cible_part_potentiel_financier_par_hectare(Variable)
         superficie = commune('superficie', period)
         communes_moins_10000 = (~outre_mer) * (population_dgf < taille_max_commune)
 
-        pot_fin_par_hectare_10000 = (np.sum(communes_moins_10000 * potentiel_financier)
-                / np.sum(communes_moins_10000 * superficie))
+        pot_fin_par_hectare_10000 = safe_divide(np.sum(communes_moins_10000 * potentiel_financier), np.sum(communes_moins_10000 * superficie))
 
-        facteur_pot_fin = max_(0, 2 - potentiel_financier_par_habitant / pot_fin_par_hectare_10000)
+        facteur_pot_fin = max_(0, safe_divide((2 * pot_fin_par_hectare_10000 - potentiel_financier_par_habitant), pot_fin_par_hectare_10000, 0))
 
         return dsr_eligible_fraction_cible * population_dgf * facteur_pot_fin
 

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/perequation.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_rurale_fractions/perequation.py
@@ -1,6 +1,7 @@
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
 from numpy import sum as sum_, where
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class dsr_eligible_fraction_perequation(Variable):
@@ -162,7 +163,7 @@ class dsr_score_attribution_perequation_part_potentiel_financier_par_habitant(Va
 
         plafond_effort_fiscal = parameters(period).dotation_solidarite_rurale.attribution.plafond_effort_fiscal
 
-        facteur_pot_fin = where(potentiel_financier_par_habitant_strate > 0, max_(0, 2 - potentiel_financier_par_habitant / potentiel_financier_par_habitant_strate), 0)
+        facteur_pot_fin = max_(0, 2 - safe_divide(potentiel_financier_par_habitant, potentiel_financier_par_habitant_strate, 0))
         facteur_effort_fiscal = min_(plafond_effort_fiscal, effort_fiscal)
 
         return dsr_eligible_fraction_perequation * population_dgf * facteur_pot_fin * facteur_effort_fiscal

--- a/openfisca_france_dotations_locales/variables/dotation_solidarite_urbaine.py
+++ b/openfisca_france_dotations_locales/variables/dotation_solidarite_urbaine.py
@@ -373,8 +373,8 @@ class dsu_montant_eligible(Variable):
         nouvellement_eligible_groupe_haut = eligible_groupe_haut * (montants_an_precedent == 0)
         toujours_eligible = toujours_eligible_groupe_bas | toujours_eligible_groupe_haut
         # Détermination des scores
-        facteur_classement_seuil_bas = np.where(rang_indice_synthetique_dsu_seuil_bas <= nombre_elig_seuil_bas, np.where(nombre_elig_seuil_bas != 1, (facteur_classement_min - facteur_classement_max) * (rang_indice_synthetique_dsu_seuil_bas - 1) / (nombre_elig_seuil_bas - 1), 0) + facteur_classement_max, 0)
-        facteur_classement_seuil_haut = np.where(rang_indice_synthetique_dsu_seuil_haut <= nombre_elig_seuil_haut, np.where(nombre_elig_seuil_haut != 1, (facteur_classement_min - facteur_classement_max) * (rang_indice_synthetique_dsu_seuil_haut - 1) / (nombre_elig_seuil_haut - 1), 0) + facteur_classement_max, 0)
+        facteur_classement_seuil_bas = np.where(rang_indice_synthetique_dsu_seuil_bas <= nombre_elig_seuil_bas, (facteur_classement_min - facteur_classement_max) * safe_divide((rang_indice_synthetique_dsu_seuil_bas - 1), (nombre_elig_seuil_bas - 1), 0) + facteur_classement_max, 0)
+        facteur_classement_seuil_haut = np.where(rang_indice_synthetique_dsu_seuil_haut <= nombre_elig_seuil_haut, (facteur_classement_min - facteur_classement_max) * safe_divide((rang_indice_synthetique_dsu_seuil_haut - 1), (nombre_elig_seuil_haut - 1), 0) + facteur_classement_max, 0)
         facteur_classement = facteur_classement_seuil_bas + facteur_classement_seuil_haut
         facteur_effort_fiscal = min_(effort_fiscal, plafond_effort_fiscal)
         facteur_qpv = (1 + np.where(population_insee > 0, poids_quartiers_prioritaires_ville * population_qpv / population_insee, 0))

--- a/openfisca_france_dotations_locales/variables/revenu.py
+++ b/openfisca_france_dotations_locales/variables/revenu.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from openfisca_core.model_api import *
 from openfisca_france_dotations_locales.entities import *
+from openfisca_france_dotations_locales.variables.base import safe_divide
 
 
 class revenu_total(Variable):
@@ -54,4 +55,4 @@ class revenu_par_habitant(Variable):
 
     def formula(commune, period, parameters):
         population_insee = commune('population_insee', period)
-        return where(population_insee > 0, commune('revenu_total', period) / population_insee, 0)
+        return safe_divide(commune('revenu_total', period), population_insee, 0)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France-Dotations-Locales",
-    version = "0.7.2",
+    version = "0.7.3",
     author = "LexImpact Team",
     author_email = "leximpact@an.fr",
     classifiers=[

--- a/tests/dotation_forfaitaire/dotation_forfaitaire.yaml
+++ b/tests/dotation_forfaitaire/dotation_forfaitaire.yaml
@@ -10,6 +10,15 @@
 
 - name: montant total écrêtement - prend en compte l'évolution DSR/DSU
   period: 2020
+  input:
+    etats:
+      IndependentBrittany:
+        communes: [Lorientgeles]
+    communes:
+      Lorientgeles:
+        population_dgf_majoree:
+          2019: 1000000000
+          2020: 1000000000
   output:
     montant_total_ecretement: 210000000  #= somme des evolutions DSR et DSU + interco
     df_montant_total_ecretement: 126000000  #= 60% * montant total ecretement
@@ -17,7 +26,15 @@
 - name: montant total écrêtement - prend en compte le montant hors dsu et dsr
   period: 2020
   input:
-    df_montant_total_ecretement_hors_dsu_dsr: 100000000  #= somme des evolutions DSR et DSU
+    etats:
+      IndependentBrittany:
+        df_montant_total_ecretement_hors_dsu_dsr: 100000000  #= somme des evolutions DSR et DSU
+        communes: [Lorientgeles]
+    communes:
+      Lorientgeles:
+        population_dgf_majoree:
+          2019: 1000000000
+          2020: 1000000000
   output:
     montant_total_ecretement: 310000000  #= somme des evolutions DSR et DSU + interco
     df_montant_total_ecretement: 186000000  #= somme des evolutions DSR et DSU + montant hors dsr / dsu

--- a/tests/dotation_solidarite_rurale/fraction_bourg_centre.yaml
+++ b/tests/dotation_solidarite_rurale/fraction_bourg_centre.yaml
@@ -109,18 +109,18 @@
 - name: DSR, éligibilité à la fraction bourg centre type 2. Conditions d'exclusion au titre de l'agglomération 
   period: 2020
   input:
-    population_dgf: [10000, 10000, 10000, 10000, 10000]
-    population_insee: [10000, 10000, 10000, 10000, 10000]
-    potentiel_financier: [10000, 10000, 10000, 10000, 10000]
-    chef_lieu_arrondissement: [True, True, True, True, True]
-    population_dgf_agglomeration: [10000, 10000, 250000, 125000, 10000]
-    part_population_agglomeration_departement: [0.09, 0.11, 0.09, 0.09, 0.09]
-    chef_lieu_departement_dans_agglomeration: [False, False, False, False, True]
-    population_dgf_maximum_commune_agglomeration: [800, 800, 80000, 100000, 800]
+    population_dgf: [10000, 10000, 10000, 10000, 10000, 1000]
+    population_insee: [10000, 10000, 10000, 10000, 10000, 1000]
+    potentiel_financier: [10000, 10000, 10000, 10000, 10000, 1000]
+    chef_lieu_arrondissement: [True, True, True, True, True, False]
+    population_dgf_agglomeration: [10000, 10000, 250000, 125000, 10000, 1000]
+    part_population_agglomeration_departement: [0.09, 0.11, 0.09, 0.09, 0.09, 0]
+    chef_lieu_departement_dans_agglomeration: [False, False, False, False, True, False]
+    population_dgf_maximum_commune_agglomeration: [800, 800, 80000, 100000, 800, 1000]
   output:
-    dsr_exclue_fraction_bourg_centre_agglomeration: [False, True, True, True, True]
-    dsr_exclue_fraction_bourg_centre_type_2: [False, True, True, True, True]
-    dsr_eligible_fraction_bourg_centre_type_2: [True, False, False, False, False]
+    dsr_exclue_fraction_bourg_centre_agglomeration: [False, True, True, True, True, False]
+    dsr_exclue_fraction_bourg_centre_type_2: [False, True, True, True, True, False]
+    dsr_eligible_fraction_bourg_centre_type_2: [True, False, False, False, False, False]
 
 
 - name: DSR, éligibilité à la fraction bourg centre type 2. Conditions d'exclusion au titre du potentiel financier 


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france_dotations_locales/variables/base.py`.
* Détails :
  - Suppression des warnings 'divide by zero' dans la fonction custom de division que nous avons écrite (et qui fait bien attention à ne pas diviser par zéro)
  
- - - -

Ces changements:
- Corrigent ou améliorent un calcul déjà existant.

- - - -